### PR TITLE
added: external sites app

### DIFF
--- a/nextcloud/Dockerfile
+++ b/nextcloud/Dockerfile
@@ -31,7 +31,7 @@ ENV PHP_MEMORY_LIMIT=512M \
     FTS_PASSWORD=changeme \
     NC_DISABLED_APPS="firstrunwizard support survey_client federation nextcloud_announcements updatenotification logreader serverinfo" \
     NC_ENABLED_APPS="suspicious_login files_external admin_audit" \
-    NC_ADDITIONAL_APPS="impersonate groupfolders deck forms terms_of_service calendar contacts mail quota_warning"
+    NC_ADDITIONAL_APPS="impersonate groupfolders deck forms terms_of_service calendar contacts mail quota_warning external"
 
 RUN apk add --no-cache samba-client && \
     apk add --no-cache --virtual .build-deps $PHPIZE_DEPS autoconf samba-dev && \


### PR DESCRIPTION
Install and enable [external sites app](https://apps.nextcloud.com/apps/external).
We'll be using this primarily in junction with apache guacamole (may have more uses for it in the future). 