### PR TITLE
fix: hide the Readme.md file in files app

### DIFF
--- a/nextcloud/var/www/html/themes/docker-cloud/core/css/server.css
+++ b/nextcloud/var/www/html/themes/docker-cloud/core/css/server.css
@@ -98,3 +98,8 @@ div.splitpanes__pane:nth-child(1) {
   justify-content: center !important;
   align-items: center !important;
 }
+
+/* files app */
+#app-content-files tr[data-file="Readme.md"] {
+    display: none;
+}


### PR DESCRIPTION
this is far from an ideal solution but it will have to do for now, perhaps a toggle switch for this would make sense