### PR TITLE
Create build_and_publish.yml

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -1,0 +1,16 @@
+name: Build and publish OCI package(s)
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  build_and_publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build and push the OCI image to ghcr.io
+        run: |
+          docker login --username ${{ github.actor }} --password ${{ secrets.GHCR_TOKEN }} ghcr.io
+          docker build ./nextcloud --tag ghcr.io/k4my4b/docker-cloud:latest
+          docker push ghcr.io/k4my4b/docker-cloud:latest


### PR DESCRIPTION
preliminary and rather simple GitHub workflow to build and publish the OCI image(s)