### PR TITLE
chore: clean up unnecessary cron directories in Dockerfile

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.19
 
-RUN apk add --no-cache parallel
+RUN apk add --no-cache parallel && rm -fr /etc/periodic /etc/crontabs/root
 
 COPY --chmod=775 init.d /init.d
 COPY --chmod=755 init.sh /init.sh


### PR DESCRIPTION
- Added removal of /etc/periodic and /etc/crontabs/root to reduce container size and eliminate unused cron jobs.